### PR TITLE
fix: use BigInt for bitwise operations in permission check

### DIFF
--- a/server/lib/permissions.ts
+++ b/server/lib/permissions.ts
@@ -52,26 +52,33 @@ export const hasPermission = (
   value: number,
   options: PermissionCheckOptions = { type: 'and' }
 ): boolean => {
-  let total = 0;
+  let total = 0n;
 
   // If we are not checking any permissions, bail out and return true
   if (permissions === 0) {
     return true;
   }
 
+  // Convert to BigInt
+  const valueBigInt = BigInt(value);
+
   if (Array.isArray(permissions)) {
-    if (value & Permission.ADMIN) {
+    if (valueBigInt & BigInt(Permission.ADMIN)) {
       return true;
     }
     switch (options.type) {
       case 'and':
-        return permissions.every((permission) => !!(value & permission));
+        return permissions.every(
+          (permission) => !!(valueBigInt & BigInt(permission))
+        );
       case 'or':
-        return permissions.some((permission) => !!(value & permission));
+        return permissions.some(
+          (permission) => !!(valueBigInt & BigInt(permission))
+        );
     }
   } else {
-    total = permissions;
+    total = BigInt(permissions);
   }
 
-  return !!(value & Permission.ADMIN) || !!(value & total);
+  return !!(valueBigInt & BigInt(Permission.ADMIN)) || !!(valueBigInt & total);
 };

--- a/src/components/PermissionOption/index.tsx
+++ b/src/components/PermissionOption/index.tsx
@@ -40,6 +40,7 @@ const PermissionOption = ({
     Permission.AUTO_APPROVE,
     Permission.AUTO_APPROVE_MOVIE,
     Permission.AUTO_APPROVE_TV,
+    Permission.AUTO_APPROVE_MUSIC,
     Permission.AUTO_APPROVE_4K,
     Permission.AUTO_APPROVE_4K_MOVIE,
     Permission.AUTO_APPROVE_4K_TV,


### PR DESCRIPTION
#### Description
Due to the permissions integers going over the 32-bit limit for bitwise operators, the permissions checkboxes don't function as expected (unable to check Request Music individually).
This PR fixes the issue by converting to BigInt before performing the operations.

#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed
